### PR TITLE
Web APIs Dockerization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,25 @@ We will create two minimal and simple Web APIs using two different Python backen
 
 ### 4. Dockerize the Web APIs
 
-TODO: Include `Dockerfile`s in this section.
+Authenticate to Azure Container Registry with Docker. Make sure that [`Admin user`](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#admin-account) is enabled.
+```bash
+docker login <ACR_NAME>.azurecr.io
+```
+
+
+**Dockerizing Django Ninja Web API**
+```bash
+cd django-ninja-api
+docker build -t <ACR_NAME>.azurecr.io/web-api-django-ninja:v0.1.0 .
+docker push <ACR_NAME>.azurecr.io/web-api-django-ninja:v0.1.0
+```
+**Dockerizing FastAPI Web API**
+```bash
+cd fastapi-api
+docker build -t <ACR_NAME>.azurecr.io/web-api-fastapi:v0.1.0 .
+docker push <ACR_NAME>.azurecr.io/web-api-fastapi:v0.1.0
+```
+
 
 ### 5. Run Docker Containers
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,46 @@ docker push <ACR_NAME>.azurecr.io/web-api-fastapi:v0.1.0
 
 ### 5. Run Docker Containers
 
-Run the following Docker commands in Azure VM:
+Enter the Azure VM via `ssh`.
 
 ```bash
-docker run -d -p 8081:8081 --name django_ninja_container django_ninja_image
-docker run -d -p 8082:8082 --name fast_api_container fast_api_image
+ssh <VM_USER>@<VM_IP>
+```
+
+Running the Docker containers can be done either by `docker run` or `docker compose`.
+
+**Using `docker run`**
+```bash
+# Django Ninja Web API
+docker run --rm -p 8081:8000 -d <ACR_NAME>.azurecr.io/web-api-django-ninja:v0.1.0 uvicorn django_ninja_api.asgi:application --host 0.0.0.0 --port 8000
+
+# FastAPI Web API
+docker run --rm -p 8082:8000 -d <ACR_NAME>.azurecr.io/web-api-fastapi:v0.1.0 fastapi run main.py --host 0.0.0.0 --port 8000
+```
+**Using `docker compose`**
+
+First, copy the `compose.yaml` from this repository file into Azure VM.
+
+Then, replace the `build` key with the `image` key, and set the value to the build images on Azure Container Registry.
+
+```bash
+services:
+
+  web-api-django-ninja:
+    ...
+    # build: ./django-ninja-api
+    image: <ACR_NAME>.azurecr.io/web-api-django-ninja:v0.1.0
+    ...
+
+  web-api-fastapi:
+    ...
+    # build: ./fastapi-api
+    image: <ACR_NAME>.azurecr.io/web-api-fastapi:v0.1.0
+    ...
+```
+Finally, run `docker compose` command. Make sure to run this in the directory where `compose.yaml` file is located at.
+```bash
+docker compose -f compose.yaml -d up
 ```
 
 **NOTE**: It might be worth accessing the two Web APIs via `http` for testing purposes; ports will be closed later on to ensure `https` access is working as mentioned in [Closing External Ports](#closing-external-ports). Please refer to the following links to expose port `8081` and `8082`:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,17 @@
+services:
+
+  web-api-django-ninja:
+    container_name: web-api-django-ninja
+    build: ./django-ninja-api
+    # image: <ACR_NAME>.azurecr.io/web-api-django-ninja:v0.1.0
+    command: uvicorn django_ninja_api.asgi:application --host 0.0.0.0 --port 8000
+    ports:
+      - 8081:8000
+
+  web-api-fastapi:
+    container_name: web-api-fastapi
+    build: ./fastapi-api
+    # image: <ACR_NAME>.azurecr.io/web-api-fastapi:v0.1.0
+    command: fastapi run main.py --host 0.0.0.0 --port 8000
+    ports:
+      - 8082:8000

--- a/django-ninja-api/.dockerignore
+++ b/django-ninja-api/.dockerignore
@@ -1,0 +1,89 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+
+# CI
+.codeclimate.yml
+.travis.yml
+.taskcluster.yml
+
+# Docker
+docker-compose.yml
+Dockerfile
+.docker
+.dockerignore
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env
+.venv/
+venv/
+
+# PyCharm
+.idea
+
+# Python mode for VIM
+.ropeproject
+**/.ropeproject
+
+# Vim swap files
+**/*.swp
+
+# VS Code
+.vscode/

--- a/django-ninja-api/Dockerfile
+++ b/django-ninja-api/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official Python runtime as a parent image
+FROM python:3.10-alpine
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Set work directory
+WORKDIR /code
+
+# Install dependencies
+COPY requirements.txt /code/
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+
+# Copy project
+COPY . /code/

--- a/fastapi-api/.dockerignore
+++ b/fastapi-api/.dockerignore
@@ -1,0 +1,89 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+
+# CI
+.codeclimate.yml
+.travis.yml
+.taskcluster.yml
+
+# Docker
+docker-compose.yml
+Dockerfile
+.docker
+.dockerignore
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env
+.venv/
+venv/
+
+# PyCharm
+.idea
+
+# Python mode for VIM
+.ropeproject
+**/.ropeproject
+
+# Vim swap files
+**/*.swp
+
+# VS Code
+.vscode/

--- a/fastapi-api/Dockerfile
+++ b/fastapi-api/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official Python runtime as a parent image
+FROM python:3.10-alpine
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Set work directory
+WORKDIR /code
+
+# Install dependencies
+COPY requirements.txt /code/
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+
+# Copy project
+COPY . /code/


### PR DESCRIPTION
# Overview
Containerization of Web APIs with Docker, as well instruction on how to run containers in Azure VM.

# Changes

- Create `Dockerfile` for Django Ninja Web API

- Create `Dockerfile` for FastAPI Web API

- Create `compose.yaml` to run all WebAPIs containers; including the option to run already build image or build the image directly when using `docker compose`

- Include instructions in root `README.md` to build and push docker images

- Include instructions in root `README.md` to run docker containers

Signed-off-by: gilangrilhami <gilangrilhami@hotmail.co.uk>